### PR TITLE
Fix CI with GHC 8.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -65,9 +65,9 @@ jobs:
             compilerVersion: 8.2.2
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.0.1
+          - compiler: ghc-8.0.2
             compilerKind: ghc
-            compilerVersion: 8.0.1
+            compilerVersion: 8.0.2
             setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.10.3


### PR DESCRIPTION
I had forgotten to run `haskell-ci regenerate` after changing
GHC 8.0.1 to 8.0.2.